### PR TITLE
Add 'archived' query param to GetSpaces endpoint

### DIFF
--- a/clickup/spaces.go
+++ b/clickup/spaces.go
@@ -168,8 +168,8 @@ func (s *SpacesService) DeleteSpace(ctx context.Context, spaceID int) (*Response
 	return resp, nil
 }
 
-func (s *SpacesService) GetSpaces(ctx context.Context, teamID string) ([]Space, *Response, error) {
-	u := fmt.Sprintf("team/%s/space", teamID)
+func (s *SpacesService) GetSpaces(ctx context.Context, teamID string, archived bool) ([]Space, *Response, error) {
+	u := fmt.Sprintf("team/%s/space?archived=%v", teamID, archived)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/example/spaces/main.go
+++ b/example/spaces/main.go
@@ -15,7 +15,7 @@ func fetchSpaces(teamId string) ([]clickup.Space, error) {
 	api_key := os.Getenv("CLICKUP_API_KEY")
 	client := clickup.NewClient(nil, api_key)
 
-	spaces, _, err := client.Spaces.GetSpaces(context.Background(), teamId)
+	spaces, _, err := client.Spaces.GetSpaces(context.Background(), teamId, false)
 	return spaces, err
 }
 


### PR DESCRIPTION
Hey! In ClickUp Spaces can be archived, so I added an "archived" query param to GetSpaces endpoint.

https://clickup.com/api/clickupreference/operation/GetSpaces/