### PR TITLE
Update tasks.go - add attachment

### DIFF
--- a/clickup/tasks.go
+++ b/clickup/tasks.go
@@ -35,8 +35,8 @@ type TaskRequest struct {
 }
 
 type CustomFieldInTaskRequest struct {
-	ID    string `json:"id"`
-	Value string `json:"value"`
+	ID    string 	  `json:"id"`
+	Value interface{} `json:"value"`
 }
 
 type Task struct {

--- a/clickup/tasks.go
+++ b/clickup/tasks.go
@@ -35,7 +35,7 @@ type TaskRequest struct {
 }
 
 type CustomFieldInTaskRequest struct {
-	ID    string 	  `json:"id"`
+	ID    string      `json:"id"`
 	Value interface{} `json:"value"`
 }
 

--- a/clickup/tasks.go
+++ b/clickup/tasks.go
@@ -72,39 +72,34 @@ type Task struct {
 	Project         ProjectOfTaskBelonging `json:"project"`
 	Folder          FolderOftaskBelonging  `json:"folder"`
 	Space           SpaceOfTaskBelonging   `json:"space"`
-	Attachments     []Attachment           `json:"attachments"`
+	Attachments     []TaskAttachment       `json:"attachments"`
 }
 
-type Attachment struct {
+type TaskAttachment struct {
 	ID               string `json:"id"`
-    	Date             string `json:"date"`
-    	Title            string `json:"title"`
-    	Type             int `json:"type"`
-    	Source           int `json:"source"`
-    	Version          int `json:"version"`
-    	Extension        string `json:"extension"`
-    	ThumbnailSmall   string `json:"thumbnail_small"`
-    	ThumbnailMedium  string `json:"thumbnail_medium"`
-    	ThumbnailLarge   string `json:"thumbnail_large"`
-    	IsFolder         bool `json:"is_folder"`
-    	Mimetype         string `json:"mimetype"`
-    	Hidden           bool `json:"hidden"`
-    	ParentId         string `json:"parent_id"`
-    	Size      	 int `json:"size"`
-    	TotalComments    int `json:"total_comments"`
-    	ResolvedComments int `json:"resolved_comments"`
-    	User             User `json:"user"`
-    	Deleted          bool `json:"deleted"`
-    	Orientation      string `json:"orientation"`
-    	Url              string `json:"url"`
-    	EmailData        string `json:"email_data"`
-    	UrlWQuery        string `json:"url_w_query"`
-    	UrlWHost         string `json:"url_w_host"`
-	TaskID           string `json:"task_id"`
-	DependsOn        string `json:"depends_on"`
+	Date             string `json:"date"`
+	Title            string `json:"title"`
 	Type             int    `json:"type"`
-	DateCreated      string `json:"date_created"`
-	Userid           string `json:"userid"`
+	Source           int    `json:"source"`
+	Version          int    `json:"version"`
+	Extension        string `json:"extension"`
+	ThumbnailSmall   string `json:"thumbnail_small"`
+	ThumbnailMedium  string `json:"thumbnail_medium"`
+	ThumbnailLarge   string `json:"thumbnail_large"`
+	IsFolder         bool   `json:"is_folder"`
+	Mimetype         string `json:"mimetype"`
+	Hidden           bool   `json:"hidden"`
+	ParentId         string `json:"parent_id"`
+	Size             int    `json:"size"`
+	TotalComments    int    `json:"total_comments"`
+	ResolvedComments int    `json:"resolved_comments"`
+	User             User   `json:"user"`
+	Deleted          bool   `json:"deleted"`
+	Orientation      string `json:"orientation"`
+	Url              string `json:"url"`
+	EmailData        string `json:"email_data"`
+	UrlWQuery        string `json:"url_w_query"`
+	UrlWHost         string `json:"url_w_host"`
 }
 
 type Dependence struct {

--- a/clickup/tasks.go
+++ b/clickup/tasks.go
@@ -72,6 +72,39 @@ type Task struct {
 	Project         ProjectOfTaskBelonging `json:"project"`
 	Folder          FolderOftaskBelonging  `json:"folder"`
 	Space           SpaceOfTaskBelonging   `json:"space"`
+	Attachments     []Attachment           `json:"attachments"`
+}
+
+type Attachment struct {
+	ID               string `json:"id"`
+    	Date             string `json:"date"`
+    	Title            string `json:"title"`
+    	Type             int `json:"type"`
+    	Source           int `json:"source"`
+    	Version          int `json:"version"`
+    	Extension        string `json:"extension"`
+    	ThumbnailSmall   string `json:"thumbnail_small"`
+    	ThumbnailMedium  string `json:"thumbnail_medium"`
+    	ThumbnailLarge   string `json:"thumbnail_large"`
+    	IsFolder         bool `json:"is_folder"`
+    	Mimetype         string `json:"mimetype"`
+    	Hidden           bool `json:"hidden"`
+    	ParentId         string `json:"parent_id"`
+    	Size      	 int `json:"size"`
+    	TotalComments    int `json:"total_comments"`
+    	ResolvedComments int `json:"resolved_comments"`
+    	User             User `json:"user"`
+    	Deleted          bool `json:"deleted"`
+    	Orientation      string `json:"orientation"`
+    	Url              string `json:"url"`
+    	EmailData        string `json:"email_data"`
+    	UrlWQuery        string `json:"url_w_query"`
+    	UrlWHost         string `json:"url_w_host"`
+	TaskID           string `json:"task_id"`
+	DependsOn        string `json:"depends_on"`
+	Type             int    `json:"type"`
+	DateCreated      string `json:"date_created"`
+	Userid           string `json:"userid"`
 }
 
 type Dependence struct {

--- a/clickup/tasks.go
+++ b/clickup/tasks.go
@@ -36,7 +36,7 @@ type TaskRequest struct {
 
 type CustomFieldInTaskRequest struct {
 	ID    string `json:"id"`
-	Value int    `json:"value"`
+	Value string `json:"value"`
 }
 
 type Task struct {


### PR DESCRIPTION
1. when we receive custom Fields, they can be of string or int type
https://clickup.com/api/clickupreference/operation/CreateTask/
2. this is not in the documentation, but when you ask for a task, e.g. `https://api.clickup.com/api/v2/task/:task_id`, it will return a collection `attachments` which is currently not in the struct. Hence the change.
I don't know why the documentation doesn't cover it, but it's confirmed by ClickUp support.
https://clickup.com/api/clickupreference/operation/GetTask/